### PR TITLE
std::array serialization cleanup

### DIFF
--- a/btas/array_adaptor.h
+++ b/btas/array_adaptor.h
@@ -10,6 +10,7 @@
 #include <btas/generic/numeric_type.h>
 #include <btas/varray/varray.h>
 #include <btas/serialization.h>
+#include <boost/version.hpp>
 #include <boost/serialization/array.hpp>
 
 namespace btas {
@@ -237,19 +238,18 @@ namespace btas {
   };
 }
 
-#ifndef BOOST_SERIALIZATION_STD_ARRAY
-#define BOOST_SERIALIZATION_STD_ARRAY
+#if BOOST_VERSION / 100 < 1056
 namespace boost {
   namespace serialization {
 
     template<class Archive, class T, size_t N>
     void serialize(Archive & ar, std::array<T,N> & a, const unsigned int version)
     {
-        ar & btas::make_array(a.data(), a.size());
+        ar & boost::serialization::make_array(a.data(), a.size());
     }
 
   } // namespace serialization
 } // namespace boost
-#endif
+#endif // boost cannot serialize std::array?
 
 #endif /* __BTAS_ARRAYADAPTOR_H_ */

--- a/btas/array_adaptor.h
+++ b/btas/array_adaptor.h
@@ -238,7 +238,9 @@ namespace btas {
   };
 }
 
-#if BOOST_VERSION / 100 < 1056
+#ifndef BOOST_SERIALIZATION_STD_ARRAY // legacy switch to disable BTAS-provided serialization of std:array
+#define BOOST_SERIALIZATION_STD_ARRAY
+#  if BOOST_VERSION / 100 < 1056
 namespace boost {
   namespace serialization {
 
@@ -250,6 +252,7 @@ namespace boost {
 
   } // namespace serialization
 } // namespace boost
-#endif // boost cannot serialize std::array?
+#  endif // boost < 1.56 does not serialize std::array ... provide our own
+#endif // not defined BOOST_SERIALIZATION_STD_ARRAY? provide our own
 
 #endif /* __BTAS_ARRAYADAPTOR_H_ */

--- a/btas/ordinal.h
+++ b/btas/ordinal.h
@@ -208,7 +208,7 @@ namespace btas {
       friend class boost::serialization::access;
       template<class Archive>
       void serialize(Archive& ar, const unsigned int version) {
-        ar & stride_ & offset_ & contiguous_;
+        ar & BOOST_SERIALIZATION_NVP(stride_) & BOOST_SERIALIZATION_NVP(offset_) & BOOST_SERIALIZATION_NVP(contiguous_);
       }
 
       stride_type stride_; //!< stride of each dimension (stride in the language of NumPy)

--- a/btas/range.h
+++ b/btas/range.h
@@ -1352,19 +1352,19 @@ namespace serialization {
   template<class Archive, CBLAS_ORDER _Order,
            typename _Index, typename _Ordinal>
   void save(Archive& ar, const btas::RangeNd<_Order, _Index, _Ordinal>& t, const unsigned int version) {
-    auto lo = t.lobound();
-    auto up = t.upbound();
+    auto lobound = t.lobound();
+    auto upbound = t.upbound();
     auto ordinal = t.ordinal();
-    ar << lo << up << ordinal;
+    ar << BOOST_SERIALIZATION_NVP(lobound) << BOOST_SERIALIZATION_NVP(upbound) << BOOST_SERIALIZATION_NVP(ordinal);
   }
   template<class Archive, CBLAS_ORDER _Order,
            typename _Index, typename _Ordinal>
   void load(Archive& ar, btas::RangeNd<_Order, _Index, _Ordinal>& t, const unsigned int version) {
     typedef typename btas::BaseRangeNd<btas::RangeNd<_Order, _Index, _Ordinal>>::index_type index_type;
-    index_type lo, up;
+    index_type lobound, upbound;
     _Ordinal ordinal;
-    ar >> lo >> up >> ordinal;
-    t = btas::RangeNd<_Order, _Index, _Ordinal>(std::move(lo), std::move(up), std::move(ordinal));
+    ar >> BOOST_SERIALIZATION_NVP(lobound) >> BOOST_SERIALIZATION_NVP(upbound) >> BOOST_SERIALIZATION_NVP(ordinal);
+    t = btas::RangeNd<_Order, _Index, _Ordinal>(std::move(lobound), std::move(upbound), std::move(ordinal));
   }
 
 }

--- a/btas/serialization.h
+++ b/btas/serialization.h
@@ -6,6 +6,8 @@
 #include <boost/serialization/array.hpp>
 
 namespace boost { namespace serialization {
+  // this is needed to serialize  efficiently corner cases, like std::vector<std::array<std::complex<T>>>.
+  // since bitwise serialization is not portable anyway, this is OK in the context of btas
   template <typename T, size_t N>
   struct is_bitwise_serializable<std::array<T,N> > : is_bitwise_serializable<T> { };
 }}

--- a/btas/serialization.h
+++ b/btas/serialization.h
@@ -1,26 +1,13 @@
 #ifndef __BTAS_SERIALIZATION_H
 #define __BTAS_SERIALIZATION_H 1
 
-#include <complex>
-#include <boost/serialization/serialization.hpp>
+#include <array>
+#include <boost/serialization/is_bitwise_serializable.hpp>
 #include <boost/serialization/array.hpp>
 
-namespace btas {
-
-  template <typename T>
-  auto make_array(T* data, const size_t n) -> decltype(boost::serialization::make_array(data, n)) {
-    return boost::serialization::make_array(data, n);
-  }
-  // specialization for complex
-  template <typename T>
-  auto make_array(std::complex<T>* data, const size_t n) -> decltype(boost::serialization::make_array(reinterpret_cast<T*>(data), 2*n)) {
-    return boost::serialization::make_array(reinterpret_cast<T*>(data), 2*n);
-  }
-  template <typename T>
-  auto make_array(const std::complex<T>* data, const size_t n) -> decltype(boost::serialization::make_array(reinterpret_cast<const T*>(data), 2*n)) {
-    return boost::serialization::make_array(reinterpret_cast<const T*>(data), 2*n);
-  }
-
-}
+namespace boost { namespace serialization {
+  template <typename T, size_t N>
+  struct is_bitwise_serializable<std::array<T,N> > : is_bitwise_serializable<T> { };
+}}
 
 #endif

--- a/btas/tensor.h
+++ b/btas/tensor.h
@@ -718,7 +718,9 @@ namespace boost {
              class _Range,
              class _Storage>
     void save(Archive& ar, const btas::Tensor<_T,_Range,_Storage>& t, const unsigned int version) {
-      ar << t.range() << t.storage();
+      const auto& range = t.range();
+      const auto& storage = t.storage();
+      ar << BOOST_SERIALIZATION_NVP(range) << BOOST_SERIALIZATION_NVP(storage);
     }
     template<class Archive,
              typename _T,
@@ -727,7 +729,7 @@ namespace boost {
     void load(Archive& ar, btas::Tensor<_T,_Range,_Storage>& t, const unsigned int version) {
       _Range range;
       _Storage storage;
-      ar >> range >> storage;
+      ar >> BOOST_SERIALIZATION_NVP(range) >> BOOST_SERIALIZATION_NVP(storage);
       t = btas::Tensor<_T,_Range,_Storage>(range, storage);
     }
 

--- a/btas/varray/varray.h
+++ b/btas/varray/varray.h
@@ -401,16 +401,19 @@ namespace boost {
   template<class Archive, typename T>
   void save (Archive& ar, const btas::varray<T>& x, const unsigned int version)
   {
-      const typename btas::varray<T>::size_type n = x.size();
-      ar << n << boost::serialization::make_array(x.data(), n);
+      const boost::serialization::collection_size_type count(x.size());
+      ar << BOOST_SERIALIZATION_NVP(count);
+      if (count != 0)
+        ar << boost::serialization::make_array(x.data(), count);
   }
   template<class Archive, typename T>
   void load (Archive& ar, btas::varray<T>& x, const unsigned int version)
   {
-      typename btas::varray<T>::size_type n;
-      ar >> n;
-      x.resize(n);
-      ar >> boost::serialization::make_array(x.data(), n);
+      boost::serialization::collection_size_type count;
+      ar >> BOOST_SERIALIZATION_NVP(count);
+      x.resize(count);
+      if (count != 0)
+        ar >> boost::serialization::make_array(x.data(), count);
   }
 
   } // namespace serialization

--- a/btas/varray/varray.h
+++ b/btas/varray/varray.h
@@ -6,6 +6,7 @@
 #include <btas/serialization.h>
 #include <boost/serialization/split_free.hpp>
 #include <boost/serialization/array.hpp>
+#include <boost/serialization/collection_size_type.hpp>
 
 namespace btas {
 

--- a/btas/varray/varray.h
+++ b/btas/varray/varray.h
@@ -402,7 +402,7 @@ namespace boost {
   void save (Archive& ar, const btas::varray<T>& x, const unsigned int version)
   {
       const typename btas::varray<T>::size_type n = x.size();
-      ar << n << btas::make_array(x.data(), x.size());
+      ar << n << boost::serialization::make_array(x.data(), n);
   }
   template<class Archive, typename T>
   void load (Archive& ar, btas::varray<T>& x, const unsigned int version)
@@ -410,7 +410,7 @@ namespace boost {
       typename btas::varray<T>::size_type n;
       ar >> n;
       x.resize(n);
-      ar >> btas::make_array(x.data(), x.size());
+      ar >> boost::serialization::make_array(x.data(), n);
   }
 
   } // namespace serialization

--- a/test/test.C
+++ b/test/test.C
@@ -271,9 +271,9 @@ int main()
       std::ofstream os(archive_fname);
       assert(os.good());
       boost::archive::binary_oarchive ar(os);
-      ar << t; // fixed-size Tensor
-      ar << A; // Tensor of Tensor
-      ar << T1; // Tensor of complex datatypes
+      ar << BOOST_SERIALIZATION_NVP(t); // fixed-size Tensor
+      ar << BOOST_SERIALIZATION_NVP(A); // Tensor of Tensor
+      ar << BOOST_SERIALIZATION_NVP(T1); // Tensor of complex datatypes
     }
     // read
     {
@@ -282,13 +282,13 @@ int main()
       boost::archive::binary_iarchive ar(is);
 
       TArray<double,3> tcopy;
-      ar >> tcopy;
+      ar >> BOOST_SERIALIZATION_NVP(tcopy);
 
       Tensor<Tensor<double>> Acopy;
-      ar >> Acopy; // Tensor of Tensor
+      ar >> BOOST_SERIALIZATION_NVP(Acopy); // Tensor of Tensor
 
       Tensor<std::array<complex<double>,3>> T1copy;
-      ar >> T1copy; // Tensor of complex datatypes
+      ar >> BOOST_SERIALIZATION_NVP(T1copy); // Tensor of complex datatypes
 
       assert(t == tcopy);
       assert(A == Acopy);

--- a/test/test.C
+++ b/test/test.C
@@ -3,8 +3,8 @@
 #include <set>
 #include <fstream>
 
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/complex.hpp>
 
 using namespace std;
@@ -270,7 +270,7 @@ int main()
     {
       std::ofstream os(archive_fname);
       assert(os.good());
-      boost::archive::text_oarchive ar(os);
+      boost::archive::binary_oarchive ar(os);
       ar << t; // fixed-size Tensor
       ar << A; // Tensor of Tensor
       ar << T1; // Tensor of complex datatypes
@@ -279,7 +279,7 @@ int main()
     {
       std::ifstream is(archive_fname);
       assert(is.good());
-      boost::archive::text_iarchive ar(is);
+      boost::archive::binary_iarchive ar(is);
 
       TArray<double,3> tcopy;
       ar >> tcopy;

--- a/unittest/tensor_test.cc
+++ b/unittest/tensor_test.cc
@@ -5,8 +5,8 @@
 #include "btas/tensorview.h"
 #include <btas/btas.h>
 #include <btas/tarray.h>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
 #include <boost/serialization/complex.hpp>
 
 #include <iostream>
@@ -263,7 +263,7 @@ TEST_CASE("Tensor Operations")
         {
           std::ofstream os(archive_fname);
           assert(os.good());
-          boost::archive::binary_oarchive ar(os);
+          boost::archive::xml_oarchive ar(os);
           ar << BOOST_SERIALIZATION_NVP(t); // fixed-size Tensor
           ar << BOOST_SERIALIZATION_NVP(A); // Tensor of Tensor
           ar << BOOST_SERIALIZATION_NVP(T1); // Tensor of complex datatypes
@@ -272,7 +272,7 @@ TEST_CASE("Tensor Operations")
         {
           std::ifstream is(archive_fname);
           assert(is.good());
-          boost::archive::binary_iarchive ar(is);
+          boost::archive::xml_iarchive ar(is);
 
           TArray<double,3> tcopy;
           ar >> BOOST_SERIALIZATION_NVP(tcopy);

--- a/unittest/tensor_test.cc
+++ b/unittest/tensor_test.cc
@@ -264,9 +264,9 @@ TEST_CASE("Tensor Operations")
           std::ofstream os(archive_fname);
           assert(os.good());
           boost::archive::binary_oarchive ar(os);
-          ar << t; // fixed-size Tensor
-          ar << A; // Tensor of Tensor
-          ar << T1; // Tensor of complex datatypes
+          ar << BOOST_SERIALIZATION_NVP(t); // fixed-size Tensor
+          ar << BOOST_SERIALIZATION_NVP(A); // Tensor of Tensor
+          ar << BOOST_SERIALIZATION_NVP(T1); // Tensor of complex datatypes
         }
         // read
         {
@@ -275,13 +275,13 @@ TEST_CASE("Tensor Operations")
           boost::archive::binary_iarchive ar(is);
 
           TArray<double,3> tcopy;
-          ar >> tcopy;
+          ar >> BOOST_SERIALIZATION_NVP(tcopy);
 
           Tensor<Tensor<double>> Acopy;
-          ar >> Acopy; // Tensor of Tensor
+          ar >> BOOST_SERIALIZATION_NVP(Acopy);
 
           Tensor<std::array<complex<double>,3>> T1copy;
-          ar >> T1copy; // Tensor of complex datatypes
+          ar >> BOOST_SERIALIZATION_NVP(T1copy);
 
           CHECK(t == tcopy);
           CHECK(A == Acopy);

--- a/unittest/tensor_test.cc
+++ b/unittest/tensor_test.cc
@@ -5,8 +5,9 @@
 #include "btas/tensorview.h"
 #include <btas/btas.h>
 #include <btas/tarray.h>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/complex.hpp>
 
 #include <iostream>
 #include <algorithm>
@@ -262,7 +263,7 @@ TEST_CASE("Tensor Operations")
         {
           std::ofstream os(archive_fname);
           assert(os.good());
-          boost::archive::text_oarchive ar(os);
+          boost::archive::binary_oarchive ar(os);
           ar << t; // fixed-size Tensor
           ar << A; // Tensor of Tensor
           ar << T1; // Tensor of complex datatypes
@@ -271,7 +272,7 @@ TEST_CASE("Tensor Operations")
         {
           std::ifstream is(archive_fname);
           assert(is.good());
-          boost::archive::text_iarchive ar(is);
+          boost::archive::binary_iarchive ar(is);
 
           TArray<double,3> tcopy;
           ar >> tcopy;


### PR DESCRIPTION
@shiozaki please check with bagel. This should make arrays of bitwise-serializable types serializable. This will probably need boost 1.56 to work optimally.

1) declared std::array<T> bitwise serializable if T is (always good idea......?)

2) switched tests to binary archives, save few secs to check whether serialization is optimized

this supersedes changes in #40 , closes #73