### PR TITLE
improve testing for boost

### DIFF
--- a/btas/array_adaptor.h
+++ b/btas/array_adaptor.h
@@ -7,9 +7,9 @@
 #include <array>
 #include <cassert>
 
-#include <boost/version.hpp>
-#include <boost/serialization/array.hpp>
-#ifdef HAVE_BOOST_CONTAINER
+#include <btas/features.h>
+
+#ifdef BTAS_HAS_BOOST_CONTAINER
 #include <boost/container/small_vector.hpp>
 #endif
 
@@ -141,7 +141,7 @@ namespace btas {
     return os;
   }
 
-#ifdef HAVE_BOOST_CONTAINER
+#ifdef BTAS_HAS_BOOST_CONTAINER
   template <typename T, size_t N>
   std::ostream& operator<<(std::ostream& os, const boost::container::small_vector<T,N>& x) {
     array_adaptor<boost::container::small_vector<T,N>>::print(x,os);
@@ -239,7 +239,7 @@ namespace std {
   struct make_unsigned<btas::varray<T> > {
       typedef btas::varray<typename make_unsigned<T>::type > type;
   };
-#ifdef HAVE_BOOST_CONTAINER
+#ifdef BTAS_HAS_BOOST_CONTAINER
   template <typename T, size_t N>
   struct make_unsigned<boost::container::small_vector<T,N> > {
       typedef boost::container::small_vector<typename make_unsigned<T>::type,N> type;
@@ -273,7 +273,7 @@ namespace btas {
   struct replace_value_type<btas::varray<T>,U> {
       typedef btas::varray<U> type;
   };
-#ifdef HAVE_BOOST_CONTAINER
+#ifdef BTAS_HAS_BOOST_CONTAINER
   template <typename T, size_t N, typename U>
   struct replace_value_type<boost::container::small_vector<T, N>,U> {
       typedef boost::container::small_vector<U, N> type;
@@ -302,10 +302,7 @@ namespace boost {
 #  endif // boost < 1.56 does not serialize std::array ... provide our own
 #endif // not defined BOOST_SERIALIZATION_STD_ARRAY? provide our own
 
-template <typename T>
-struct type_printer;
-
-#ifdef HAVE_BOOST_CONTAINER
+#ifdef BTAS_HAS_BOOST_CONTAINER
 namespace boost {
   namespace serialization {
 

--- a/btas/defaults.h
+++ b/btas/defaults.h
@@ -8,7 +8,9 @@
 #ifndef BTAS_DEFAULTS_H_
 #define BTAS_DEFAULTS_H_
 
-#ifdef HAVE_BOOST_CONTAINER
+#include <btas/features.h>
+
+#ifdef BTAS_HAS_BOOST_CONTAINER
 #include <boost/container/small_vector.hpp>
 #else
 #include <btas/varray/varray.h>
@@ -22,13 +24,16 @@ namespace btas {
 namespace DEFAULT {
 
 /// default index type
-#ifdef HAVE_BOOST_CONTAINER
-# ifndef BTAS_TARGET_MAX_INDEX_RANK
-# define BTAS_TARGET_MAX_INDEX_RANK 6
-# endif
-template <typename Integer> using index = boost::container::small_vector<Integer, BTAS_TARGET_MAX_INDEX_RANK>;
+#ifdef BTAS_HAS_BOOST_CONTAINER
+#ifndef BTAS_TARGET_MAX_INDEX_RANK
+#define BTAS_TARGET_MAX_INDEX_RANK 6
+#endif
+template <typename Integer>
+using index =
+    boost::container::small_vector<Integer, BTAS_TARGET_MAX_INDEX_RANK>;
 #else
-template <typename Integer> using index = btas::varray<Integer>;
+template <typename Integer>
+using index = btas::varray<Integer>;
 #endif
 using index_type = index<long>;
 

--- a/btas/features.h
+++ b/btas/features.h
@@ -1,0 +1,35 @@
+/**
+ * @file features.h
+ *
+ * include this to import macros describing features of BTAS
+ * the only available macros are:
+ * - BTAS_IS_USABLE : #define'd to 1 if BTAS is usable, 0 otherwise
+ * - BTAS_HAS_BOOST_CONTAINER : #define'd to 1 if BTAS detected Boost.Container (header-only) library
+ * - BTAS_HAS_BOOST_SERIALIZATION : #define'd to 1 if BTAS detected Boost.Serialization library
+ */
+
+#ifndef BTAS_FEATURES_H_
+#define BTAS_FEATURES_H_
+
+#ifdef __has_include
+#if !defined(BTAS_HAS_BOOST_ITERATOR) && \
+    __has_include(<boost/iterator/transform_iterator.hpp>)
+#define BTAS_HAS_BOOST_ITERATOR 1
+#endif  // define BTAS_HAS_BOOST_ITERATOR if Boost.Iterator headers are
+        // available
+
+#if !defined(BTAS_HAS_BOOST_CONTAINER) && \
+    __has_include(<boost/container/small_vector.hpp>)
+#define BTAS_HAS_BOOST_CONTAINER 1
+#endif  // define BTAS_HAS_BOOST_CONTAINER if Boost.Container headers are
+        // available
+
+#endif  // defined( __has_include)
+
+#ifdef BTAS_HAS_BOOST_ITERATOR
+#define BTAS_IS_USABLE 1
+#else
+#define BTAS_IS_USABLE 0
+#endif
+
+#endif /* BTAS_FEATURES_H_ */

--- a/btas/ordinal.h
+++ b/btas/ordinal.h
@@ -8,12 +8,12 @@
 #ifndef BTAS_ORDINAL_H_
 #define BTAS_ORDINAL_H_
 
+#include <cassert>
+
 #include <btas/types.h>
 #include <btas/defaults.h>
 #include <btas/array_adaptor.h>
 #include <btas/index_traits.h>
-
-#include <boost/assert.hpp>
 
 namespace btas {
 
@@ -39,8 +39,8 @@ namespace btas {
       friend class BoxOrdinal;
 
       BoxOrdinal() {
-        BOOST_ASSERT((contiguous_ = false) || true); // workaround for Boost serialization
-                                                     // it breaks Debug builds when reading uninitialized bools
+        assert((contiguous_ = false) || true); // workaround for Boost serialization
+                                               // it breaks Debug builds when reading uninitialized bools
       }
 
       template <typename Index1,
@@ -150,7 +150,7 @@ namespace btas {
       template <typename I>
       typename std::enable_if<std::is_integral<I>::value, bool>::type
       includes(const I& ord) const {
-        assert(false); // "BoxOrdinal::includes() is not not yet implemented"
+        assert(false && "BoxOrdinal::includes() is not not yet implemented");
       }
 
     private:

--- a/btas/range.h
+++ b/btas/range.h
@@ -9,12 +9,19 @@
 #define BTAS_RANGE_H_
 
 #include <algorithm>
-#include <vector>
 #include <functional>
-#include <numeric>
 #include <initializer_list>
+#include <numeric>
+#include <vector>
 
+#include <btas/features.h>
+
+#ifndef BTAS_HAS_BOOST_ITERATOR
+#error \
+    "BTAS is cannot be used without Boost.Iterator; add Boost dir to the include path"
+#else
 #include <boost/iterator/transform_iterator.hpp>
+#endif
 
 #include <btas/defaults.h>
 #include <btas/range_iterator.h>

--- a/btas/serialization.h
+++ b/btas/serialization.h
@@ -1,7 +1,9 @@
 #ifndef __BTAS_SERIALIZATION_H
 #define __BTAS_SERIALIZATION_H 1
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
 #include <array>
+#include <boost/version.hpp>
 #include <boost/serialization/is_bitwise_serializable.hpp>
 #include <boost/serialization/array.hpp>
 
@@ -11,5 +13,6 @@ namespace boost { namespace serialization {
   template <typename T, size_t N>
   struct is_bitwise_serializable<std::array<T,N> > : is_bitwise_serializable<T> { };
 }}
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
 
 #endif

--- a/btas/tensor.h
+++ b/btas/tensor.h
@@ -13,8 +13,10 @@
 #include <btas/tensorview.h>
 #include <btas/array_adaptor.h>
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/vector.hpp>
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
 
 namespace btas {
 
@@ -700,6 +702,7 @@ namespace btas {
 
 } // namespace btas
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
 namespace boost {
   namespace serialization {
 
@@ -733,5 +736,6 @@ namespace boost {
 
   } // namespace serialization
 } // namespace boost
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
 
 #endif // __BTAS_TENSOR_H

--- a/btas/varray/varray.h
+++ b/btas/varray/varray.h
@@ -4,9 +4,12 @@
 #include <algorithm>
 #include <cassert>
 #include <btas/serialization.h>
+
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
 #include <boost/serialization/split_free.hpp>
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/collection_size_type.hpp>
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
 
 namespace btas {
 
@@ -100,7 +103,9 @@ private:
    allocator_type& alloc() { return static_cast<allocator_type&>(*this); }
    const allocator_type& alloc() const { return static_cast<const allocator_type&>(*this); }
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
    friend class boost::serialization::access;
+#endif
 
 public:
 
@@ -390,6 +395,7 @@ inline bool operator!= (const btas::varray<T>& a,
 
 } // namespace btas
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
 namespace boost {
   namespace serialization {
 
@@ -419,6 +425,7 @@ namespace boost {
 
   } // namespace serialization
 } // namespace boost
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
 
 template <typename T>
 inline bool operator== (const btas::varray<T>& a,

--- a/external/boost.cmake
+++ b/external/boost.cmake
@@ -8,100 +8,92 @@ endif()
 
 # Check for Boost, unless told otherwise (then must set Boost_FOUND, Boost_INCLUDE_DIRS, Boost_LIBRARIES)
 if (NOT SKIP_BOOST_SEARCH)
-  find_package(Boost 1.33 REQUIRED COMPONENTS serialization OPTIONAL_COMPONENTS container)
+  find_package(Boost 1.33 REQUIRED OPTIONAL_COMPONENTS serialization container)
 endif()
 
-if (Boost_FOUND)
+# Perform a compile check with Boost
+list(APPEND CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
+list(APPEND CMAKE_REQUIRED_LIBRARIES ${Boost_LIBRARIES})
+add_definitions(-DBTAS_HAS_BOOST_ITERATOR=1)
+if (Boost_CONTAINER_FOUND)
+  add_definitions(-DBTAS_HAS_BOOST_CONTAINER=1 -DBTAS_TARGET_MAX_INDEX_RANK=${TARGET_MAX_INDEX_RANK})
+endif()
 
-  # Perform a compile check with Boost
-  list(APPEND CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
-  list(APPEND CMAKE_REQUIRED_LIBRARIES ${Boost_LIBRARIES})
-  if (Boost_CONTAINER_FOUND)
-    add_definitions(-DHAVE_BOOST_CONTAINER=1 -DBTAS_TARGET_MAX_INDEX_RANK=${TARGET_MAX_INDEX_RANK})
-  endif()
+include(CheckCXXSourceRuns)
 
-  include(CheckCXXSourceRuns)
-
-  CHECK_CXX_SOURCE_RUNS(
-      "
-      #define BOOST_TEST_MAIN main_tester
-      #include <boost/test/included/unit_test.hpp>
-      
-      #include <fstream>
-      #include <cstdio>
-      #include <boost/archive/text_oarchive.hpp>
-      #include <boost/archive/text_iarchive.hpp>
-      #ifdef HAVE_BOOST_CONTAINER
-      #  include <boost/container/small_vector.hpp>
-      #endif
-      
-      class A {
-        public:
-          A() : a_(0) {}
-          A(int a) : a_(a) {}
-          bool operator==(const A& other) const {
-            return a_ == other.a_;
-          }
-        private:
-          int a_;
-          
-          friend class boost::serialization::access;
-          template<class Archive>
-          void serialize(Archive & ar, const unsigned int version)
-          {
-            ar & a_;
-          }
-      };
-
-      BOOST_AUTO_TEST_CASE( serialization )
-      {
-        BOOST_CHECK( true );
+CHECK_CXX_SOURCE_RUNS(
+    "
+    #define BOOST_TEST_MAIN main_tester
+    #include <boost/test/included/unit_test.hpp>
+    
+    #include <fstream>
+    #include <cstdio>
+    #include <boost/archive/text_oarchive.hpp>
+    #include <boost/archive/text_iarchive.hpp>
+    #ifdef BTAS_HAS_BOOST_CONTAINER
+    #  include <boost/container/small_vector.hpp>
+    #endif
+    
+    class A {
+      public:
+        A() : a_(0) {}
+        A(int a) : a_(a) {}
+        bool operator==(const A& other) const {
+          return a_ == other.a_;
+        }
+      private:
+        int a_;
         
-        A i(1);
-        const char* fname = \"tmp.boost\";
-        std::ofstream ofs(fname);
+        friend class boost::serialization::access;
+        template<class Archive>
+        void serialize(Archive & ar, const unsigned int version)
         {
-          boost::archive::text_oarchive oa(ofs);
-          oa << i;
+          ar & a_;
         }
-        {
-          std::ifstream ifs(fname);
-          boost::archive::text_iarchive ia(ifs);
-          A i_restored;
-          ia >> i_restored;
-          BOOST_CHECK(i == i_restored);
-          remove(fname);
-        }
-      }
+    };
+
+    BOOST_AUTO_TEST_CASE( serialization )
+    {
+      BOOST_CHECK( true );
       
-      #ifdef HAVE_BOOST_CONTAINER
-      BOOST_AUTO_TEST_CASE( container )
+      A i(1);
+      const char* fname = \"tmp.boost\";
+      std::ofstream ofs(fname);
       {
-        boost::container::small_vector<int, 1> v;
-        BOOST_CHECK_NO_THROW(v.push_back(0));
-        BOOST_CHECK_NO_THROW(v.push_back(1));
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
+        boost::archive::text_oarchive oa(ofs);
+        oa << i;
       }
-      #endif  // HAVE_BOOST_CONTAINER
-      "  BOOST_COMPILES_AND_RUNS)
+      {
+        std::ifstream ifs(fname);
+        boost::archive::text_iarchive ia(ifs);
+        A i_restored;
+        ia >> i_restored;
+        BOOST_CHECK(i == i_restored);
+        remove(fname);
+      }
+    }
+    
+    #ifdef BTAS_HAS_BOOST_CONTAINER
+    BOOST_AUTO_TEST_CASE( container )
+    {
+      boost::container::small_vector<int, 1> v;
+      BOOST_CHECK_NO_THROW(v.push_back(0));
+      BOOST_CHECK_NO_THROW(v.push_back(1));
+      BOOST_CHECK(v[0] == 0);
+      BOOST_CHECK(v[1] == 1);
+    }
+    #endif  // BTAS_HAS_BOOST_CONTAINER
+    "  BOOST_COMPILES_AND_RUNS)
 
-  if (NOT BOOST_COMPILES_AND_RUNS)
-    message(FATAL_ERROR "Boost found at ${BOOST_ROOT}, but could not compile and/or run test program")
-  endif(NOT BOOST_COMPILES_AND_RUNS)
-  
-else()
+if (BOOST_COMPILES_AND_RUNS)
+    add_definitions(-DBTAS_HAS_BOOST_SERIALIZATION=1)
+else ()
+  message(STATUS "Boost found at ${BOOST_ROOT}, but could not compile and/or run test program")
+  message(WARNING "To obtain usable Boost, use your system package manager (HomeBrew, apt, etc.) OR download at www.boost.org and compile (unpacking alone is not enough)")
+  message(WARNING "** !! due to missing Boost.Serialization the corresponding unit tests will be disabled !!")
+endif(BOOST_COMPILES_AND_RUNS)
 
-  # compiling boost properly is too hard ... ask to come back
-  message("** BOOST_ROOT was not explicitly set and Boost serialization library was not found")
-
+if (NOT BOOST_COMPILES_AND_RUNS)
 endif()
 
-if (NOT Boost_INCLUDE_DIRS)
-  message(WARNING "Boost_INCLUDE_DIRS = ${Boost_INCLUDE_DIRS}")
-  message(WARNING "Boost serialization library not found, set BOOST_ROOT to search in the right place (cmake -DBOOST_ROOT=...); if do not have Boost, download at www.boost.org and compile (unpacking alone is not enough)")
-  message(WARNING "** !! unit tests will be disabled !!")
-  set(BTAS_BUILD_UNITTEST OFF)
-else()
-  include_directories(${Boost_INCLUDE_DIRS})
-endif()
+include_directories(${Boost_INCLUDE_DIRS})

--- a/test/test.C
+++ b/test/test.C
@@ -3,9 +3,11 @@
 #include <set>
 #include <fstream>
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/complex.hpp>
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
 
 using namespace std;
 
@@ -259,6 +261,7 @@ int main()
     gemm(CblasNoTrans, CblasTrans, 1.0, a, b, 0.0, c);
   }
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
   // test 11: serialization
   {
     const auto archive_fname = "test1.archive";
@@ -296,6 +299,7 @@ int main()
     }
     std::remove(archive_fname);
   }
+#endif
 
   //////////////////////////////////////////////////////////////////////////////
   // CoRange tests

--- a/unittest/tensor_test.cc
+++ b/unittest/tensor_test.cc
@@ -1,9 +1,6 @@
 #include "btas/tensor.h"
 #include <btas/btas.h>
 #include <btas/tarray.h>
-#include <boost/archive/xml_iarchive.hpp>
-#include <boost/archive/xml_oarchive.hpp>
-#include <boost/serialization/complex.hpp>
 #include <random>
 #include "btas/tarray.h"
 #include "btas/tensorview.h"
@@ -13,6 +10,12 @@
 #include <fstream>
 #include <iostream>
 #include <set>
+
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/serialization/complex.hpp>
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
 
 using std::cout;
 using std::endl;
@@ -239,6 +242,7 @@ TEST_CASE("Tensor Operations") {
     CHECK(dot(Ctest1, Ctest1) < eps_double);
   }
 
+#ifdef BTAS_HAS_BOOST_SERIALIZATION
   SECTION("Serialization") {
     const auto archive_fname = "tensor_operations.serialization.archive";
 
@@ -280,4 +284,6 @@ TEST_CASE("Tensor Operations") {
     }
     std::remove(archive_fname);
   }
+#endif  // BTAS_HAS_BOOST_SERIALIZATION
+
 }


### PR DESCRIPTION
- unit tests no longer require boost.seralization (serialization tests will be skipped without it)
- boost/features.h defined BTAS_IS_USABLE to help using BTAS as header-only lib without cmake involvement