### PR TITLE
more generic on _Range template in btas::Tensor

### DIFF
--- a/btas/tensor.h
+++ b/btas/tensor.h
@@ -285,14 +285,6 @@ namespace btas {
         return range_;
       }
 
-      /// \param d dimension
-      /// \return subrange for dimension \d
-      const Range1d<typename index_type::value_type>
-      range(size_t d) const
-      {
-        return range_.range(d);
-      }
-
       /// \return range's extent object
       typename range_type::extent_type
       extent() const


### PR DESCRIPTION
Removed function `const Range1d<typename index_type::value_type> range(size_t d) const;` in `Tensor`. This function forces the template `_Range` to return a btas internal class `Range1d`, which makes using external `_Range` class harder. 
Removing this function will require some interface changes, since now user has to call `tensor.range().range(index)` to get the `Range1d` object. 
Will check if this breaks any tests later.