### PR TITLE
Add btas::zb::RangeNd for slimmer zero-based ranges

### DIFF
--- a/btas/generic/permute.h
+++ b/btas/generic/permute.h
@@ -36,7 +36,7 @@ namespace btas {
         ++itrY;
       }
     };
-    if (r_is_permutable)
+    if constexpr (r_is_permutable)
       do_perm(X, Y, permute(r, p));
     else {
       do_perm(X, Y, permute(btas::Range(r.lobound(), r.upbound(), r.stride()), p));

--- a/btas/tensor.h
+++ b/btas/tensor.h
@@ -144,6 +144,25 @@ namespace btas {
       }
     }
 
+    /// construct from \c range object, fill each element from \c gen called on
+    /// the element's multi-index. \c gen must be callable with the range's
+    /// iteration value (its multi-index) and return a value convertible to
+    /// \c value_type.
+    template <typename Range, typename F,
+              typename = std::enable_if_t<
+                  btas::is_boxrange<Range>::value &&
+                  std::is_invocable_r_v<
+                      value_type, F,
+                      decltype(*std::begin(std::declval<const Range&>()))>>>
+    Tensor(const Range& range, F&& gen)
+        : range_(range.lobound(), range.upbound()) {
+      array_adaptor<storage_type>::resize(storage_, range_.area());
+      auto out_it = begin();
+      for (auto&& idx : range_) {
+        *out_it++ = gen(idx);
+      }
+    }
+
     /// construct from \c range and \c storage
     template <typename Range, typename Storage>
     Tensor(const Range& range, const Storage& storage,

--- a/btas/tensor.h
+++ b/btas/tensor.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <iterator>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace btas {

--- a/btas/tensor.h
+++ b/btas/tensor.h
@@ -154,13 +154,13 @@ namespace btas {
                   btas::is_boxrange<Range>::value &&
                   std::is_invocable_r_v<
                       value_type, F,
-                      decltype(*std::begin(std::declval<const Range&>()))>>>
+                      decltype(*std::begin(std::declval<const range_type&>()))>>>
     Tensor(const Range& range, F&& gen)
         : range_(range.lobound(), range.upbound()) {
       array_adaptor<storage_type>::resize(storage_, range_.area());
       auto out_it = begin();
       for (auto&& idx : range_) {
-        *out_it++ = gen(idx);
+        *out_it++ = std::invoke(std::forward<F>(gen), idx);
       }
     }
 

--- a/btas/zb/range.h
+++ b/btas/zb/range.h
@@ -12,6 +12,7 @@
 
 #include <btas/fwd.h>
 
+#include <btas/error.h>
 #include <btas/index_traits.h>
 #include <btas/range_iterator.h>
 #include <btas/range_traits.h>
@@ -19,7 +20,6 @@
 #include <btas/types.h>
 
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -87,8 +87,8 @@ class index {
   constexpr reference operator[](size_type i) noexcept { return data_[i]; }
   constexpr const_reference operator[](size_type i) const noexcept { return data_[i]; }
 
-  constexpr reference at(size_type i) { assert(i < size_); return data_[i]; }
-  constexpr const_reference at(size_type i) const { assert(i < size_); return data_[i]; }
+  constexpr reference at(size_type i) { BTAS_ASSERT(i < size_); return data_[i]; }
+  constexpr const_reference at(size_type i) const { BTAS_ASSERT(i < size_); return data_[i]; }
 
   constexpr iterator begin() noexcept { return data_.data(); }
   constexpr iterator end() noexcept { return data_.data() + size_; }
@@ -119,7 +119,7 @@ class index {
 
  private:
   static constexpr std::uint8_t check_size(size_type n) {
-    assert(n <= MaxRank);
+    BTAS_ASSERT(n <= MaxRank);
     return static_cast<std::uint8_t>(n);
   }
 
@@ -158,7 +158,7 @@ class ordinal_view {
   template <typename Index>
   std::enable_if_t<is_index<Index>::value, Ord>
   operator()(const Index& idx) const {
-    assert(static_cast<std::size_t>(idx.size()) == rank_);
+    BTAS_ASSERT(static_cast<std::size_t>(idx.size()) == rank_);
     using std::cbegin;
     Ord o{0};
     auto it = cbegin(idx);
@@ -230,6 +230,23 @@ class RangeNd {
       : extent_({static_cast<Ext>(e0), static_cast<Ext>(e1),
                  static_cast<Ext>(es)...}) {}
 
+  /// Construct from lobound/upbound pair. \c lobound must be all zeros
+  /// (zero-based ranges); \c upbound becomes the extent. Useful because
+  /// downstream code such as @c btas::Tensor 's @c (range, storage) ctor
+  /// instantiates @c range_type(lobound, upbound) even when the runtime
+  /// branch would not take that path.
+  template <typename Lo, typename Up,
+            typename = std::enable_if_t<is_index<std::decay_t<Lo>>::value &&
+                                        is_index<std::decay_t<Up>>::value>>
+  RangeNd(const Lo& lobound, const Up& upbound) : extent_(upbound) {
+    (void)lobound;
+    using std::cbegin;
+    using std::cend;
+    BTAS_ASSERT(std::all_of(cbegin(lobound), cend(lobound),
+                       [](auto v) { return v == 0; }) &&
+           "btas::zb::RangeNd: lobound must be all zeros");
+  }
+
   //
   // Rank, extent, lo/up bounds
   //
@@ -270,7 +287,7 @@ class RangeNd {
 
   template <typename I>
   std::enable_if_t<is_index<I>::value, Ord> ordinal(const I& idx) const {
-    assert(static_cast<std::size_t>(idx.size()) == rank());
+    BTAS_ASSERT(static_cast<std::size_t>(idx.size()) == rank());
     using std::cbegin;
     auto it = cbegin(idx);
     const auto r = rank();

--- a/btas/zb/range.h
+++ b/btas/zb/range.h
@@ -2,9 +2,9 @@
  * zb/range.h
  *
  *  Slimmed-down version of RangeNd for zero-based indexing apps. State is just (extent[], rank); lobound is
- *  structurally zero, upbound = extent, strides are derived row-major on demand.
+ *  structurally zero, upbound = extent, strides are derived from extent (per the requested layout) on demand.
  *
- *  sizeof(zb::RangeNd<6, int16_t, int32_t>) == 14 (vs ~304 for btas::Range).
+ *  sizeof(zb::RangeNd<>) == 14 (vs ~304 for btas::Range).
  */
 
 #ifndef BTAS_ZB_RANGE_H_
@@ -19,12 +19,14 @@
 #include <btas/serialization.h>
 #include <btas/types.h>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
 #include <iterator>
 #include <type_traits>
+#include <utility>
 
 namespace btas {
 namespace zb {
@@ -37,6 +39,10 @@ namespace zb {
 template <std::size_t MaxRank, typename Int>
 class index {
  public:
+  // size_ is stored as a uint8_t so MaxRank must fit
+  static_assert(MaxRank > 0 && MaxRank < 256,
+                "btas::zb::index: MaxRank must lie in (0, 256)");
+
   using value_type = Int;
   using size_type = std::size_t;
   using reference = Int&;
@@ -128,13 +134,14 @@ class index {
 };
 
 /// Lightweight value type returned by \c RangeNd::ordinal() . Synthesizes
-/// strides from extent at construction; offset is always 0 and the range is
-/// always contiguous, by construction.
-template <std::size_t MaxRank, typename Ord>
+/// strides from extent at construction (row- or column-major per \c _Order );
+/// offset is always 0 and the range is always contiguous, by construction.
+template <::blas::Layout _Order, std::size_t MaxRank, typename Ord>
 class ordinal_view {
  public:
   using value_type = Ord;
   using stride_type = std::array<Ord, MaxRank>;
+  static constexpr ::blas::Layout order = _Order;
 
   ordinal_view() noexcept : stride_{}, rank_(0) {}
 
@@ -143,9 +150,19 @@ class ordinal_view {
     using std::cbegin;
     auto it = cbegin(ext);
     Ord vol{1};
-    for (std::ptrdiff_t i = static_cast<std::ptrdiff_t>(rank) - 1; i >= 0; --i) {
-      stride_[i] = vol;
-      vol *= static_cast<Ord>(*(it + i));
+    if constexpr (_Order == ::blas::Layout::RowMajor) {
+      // last dim is fastest: stride[N-1]=1, stride[i]=stride[i+1]*extent[i+1]
+      for (std::ptrdiff_t i = static_cast<std::ptrdiff_t>(rank) - 1; i >= 0;
+           --i) {
+        stride_[i] = vol;
+        vol *= static_cast<Ord>(*(it + i));
+      }
+    } else {
+      // first dim is fastest: stride[0]=1, stride[i]=stride[i-1]*extent[i-1]
+      for (std::size_t i = 0; i < rank; ++i) {
+        stride_[i] = vol;
+        vol *= static_cast<Ord>(*(it + i));
+      }
     }
   }
 
@@ -172,14 +189,20 @@ class ordinal_view {
   std::size_t rank_;
 };
 
-/// Zero-based row-major N-dim range optimized for applications with zero-based indexing.
+/// Zero-based N-dim range optimized for applications with zero-based indexing.
 ///
-/// \tparam MaxRank static cap on rank (default 6)
+/// Template parameter order matches \c btas::RangeNd (layout first, index/
+/// ordinal types next), with the static rank cap moved to the end so the
+/// common default form \c zb::RangeNd<> stays a single token.
+///
+/// \tparam _Order  data layout (default RowMajor)
 /// \tparam Ext     per-dim extent integer type (default int16_t)
 /// \tparam Ord     ordinal integer type (default int32_t)
-template <std::size_t MaxRank = 6,
+/// \tparam MaxRank static cap on rank (default 6)
+template <::blas::Layout _Order = ::blas::Layout::RowMajor,
           typename Ext = std::int16_t,
-          typename Ord = std::int32_t>
+          typename Ord = std::int32_t,
+          std::size_t MaxRank = 6>
 class RangeNd {
  public:
   static_assert(MaxRank > 0 && MaxRank < 256, "MaxRank must lie in (0, 256)");
@@ -187,7 +210,7 @@ class RangeNd {
   static_assert(std::is_integral_v<Ord> && std::is_signed_v<Ord>,
                 "Ord must be a signed integer type");
 
-  static constexpr ::blas::Layout order = ::blas::Layout::RowMajor;
+  static constexpr ::blas::Layout order = _Order;
   static constexpr std::size_t max_rank = MaxRank;
 
   using extent_type = index<MaxRank, Ext>;
@@ -278,19 +301,19 @@ class RangeNd {
   const Ext* upbound_data() const noexcept { return extent_.data(); }
 
   //
-  // Ordinal mapping (synthesized row-major; nothing stored)
+  // Ordinal mapping (synthesized from extent per _Order; nothing stored)
   //
 
-  ordinal_view<MaxRank, Ord> ordinal() const {
-    return ordinal_view<MaxRank, Ord>(extent_, rank());
+  ordinal_view<_Order, MaxRank, Ord> ordinal() const {
+    return ordinal_view<_Order, MaxRank, Ord>(extent_, rank());
   }
 
-  /// Row-major strides synthesized on demand. Returned by value (not by
+  /// Strides synthesized on demand per \c _Order . Returned by value (not by
   /// reference) so nothing is stored in the range itself — preserves the
   /// packed footprint. Callers that need a pointer (e.g. the BTAS generic
   /// permute, which forwards r.stride() into a btas::Range ctor) bind the
   /// temporary to a const& and copy from it.
-  using stride_type = typename ordinal_view<MaxRank, Ord>::stride_type;
+  using stride_type = typename ordinal_view<_Order, MaxRank, Ord>::stride_type;
   stride_type stride() const noexcept {
     return ordinal().stride();
   }
@@ -303,9 +326,16 @@ class RangeNd {
     const auto r = rank();
     Ord o{0};
     Ord vol{1};
-    for (std::ptrdiff_t i = static_cast<std::ptrdiff_t>(r) - 1; i >= 0; --i) {
-      o += static_cast<Ord>(*(it + i)) * vol;
-      vol *= static_cast<Ord>(extent_[i]);
+    if constexpr (_Order == ::blas::Layout::RowMajor) {
+      for (std::ptrdiff_t i = static_cast<std::ptrdiff_t>(r) - 1; i >= 0; --i) {
+        o += static_cast<Ord>(*(it + i)) * vol;
+        vol *= static_cast<Ord>(extent_[i]);
+      }
+    } else {
+      for (std::size_t i = 0; i < r; ++i) {
+        o += static_cast<Ord>(*(it + i)) * vol;
+        vol *= static_cast<Ord>(extent_[i]);
+      }
     }
     return o;
   }
@@ -319,15 +349,26 @@ class RangeNd {
   const_iterator cbegin() const { return begin(); }
   const_iterator cend() const { return end(); }
 
-  /// Row-major in-place increment used by \c RangeIterator . After the final
-  /// valid index, idx == upbound() (== extent_), which matches \c end() .
+  /// In-place increment used by \c RangeIterator , layout-aware per \c _Order .
+  /// After the final valid index, idx == upbound() (== extent_), which matches
+  /// \c end() .
   void increment(index_type& idx) const {
     const auto r = rank();
     if (r == 0) return;
-    for (std::ptrdiff_t d = static_cast<std::ptrdiff_t>(r) - 1; d >= 0; --d) {
-      ++idx[d];
-      if (idx[d] < extent_[d]) return;
-      idx[d] = Ext{0};
+    if constexpr (_Order == ::blas::Layout::RowMajor) {
+      // last dim varies fastest
+      for (std::ptrdiff_t d = static_cast<std::ptrdiff_t>(r) - 1; d >= 0; --d) {
+        ++idx[d];
+        if (idx[d] < extent_[d]) return;
+        idx[d] = Ext{0};
+      }
+    } else {
+      // first dim varies fastest
+      for (std::size_t d = 0; d < r; ++d) {
+        ++idx[d];
+        if (idx[d] < extent_[d]) return;
+        idx[d] = Ext{0};
+      }
     }
     for (std::size_t d = 0; d < r; ++d) idx[d] = extent_[d];
   }
@@ -359,9 +400,10 @@ class RangeNd {
   extent_type extent_{};
 };
 
-template <std::size_t MaxRank, typename Ext, typename Ord>
-inline void swap(RangeNd<MaxRank, Ext, Ord>& a,
-                 RangeNd<MaxRank, Ext, Ord>& b) noexcept {
+template <::blas::Layout _Order, typename Ext, typename Ord,
+          std::size_t MaxRank>
+inline void swap(RangeNd<_Order, Ext, Ord, MaxRank>& a,
+                 RangeNd<_Order, Ext, Ord, MaxRank>& b) noexcept {
   a.swap(b);
 }
 
@@ -371,23 +413,27 @@ inline void swap(RangeNd<MaxRank, Ext, Ord>& a,
 // Trait specializations placing zb::RangeNd into the BTAS Range concept.
 //
 
-template <std::size_t MaxRank, typename Ext, typename Ord>
-struct range_traits<zb::RangeNd<MaxRank, Ext, Ord>> {
-  static constexpr ::blas::Layout order = ::blas::Layout::RowMajor;
-  using index_type = typename zb::RangeNd<MaxRank, Ext, Ord>::index_type;
+template <::blas::Layout _Order, typename Ext, typename Ord,
+          std::size_t MaxRank>
+struct range_traits<zb::RangeNd<_Order, Ext, Ord, MaxRank>> {
+  static constexpr ::blas::Layout order = _Order;
+  using index_type =
+      typename zb::RangeNd<_Order, Ext, Ord, MaxRank>::index_type;
   using ordinal_type = Ord;
   static constexpr bool is_general_layout = false;
 };
 
-template <std::size_t MaxRank, typename Ext, typename Ord>
-class boxrange_iteration_order<zb::RangeNd<MaxRank, Ext, Ord>> {
+template <::blas::Layout _Order, typename Ext, typename Ord,
+          std::size_t MaxRank>
+class boxrange_iteration_order<zb::RangeNd<_Order, Ext, Ord, MaxRank>> {
  public:
   enum {
     row_major = boxrange_iteration_order<void>::row_major,
     other = boxrange_iteration_order<void>::other,
     column_major = boxrange_iteration_order<void>::column_major
   };
-  static constexpr int value = row_major;
+  static constexpr int value =
+      (_Order == ::blas::Layout::RowMajor) ? row_major : column_major;
 };
 
 }  // namespace btas
@@ -400,23 +446,31 @@ class boxrange_iteration_order<zb::RangeNd<MaxRank, Ext, Ord>> {
 namespace madness {
 namespace archive {
 
-template <class Archive, std::size_t MaxRank, typename Ext, typename Ord>
-struct ArchiveLoadImpl<Archive, btas::zb::RangeNd<MaxRank, Ext, Ord>> {
+template <class Archive, ::blas::Layout _Order, typename Ext, typename Ord,
+          std::size_t MaxRank>
+struct ArchiveLoadImpl<Archive, btas::zb::RangeNd<_Order, Ext, Ord, MaxRank>> {
   static inline void load(const Archive& ar,
-                          btas::zb::RangeNd<MaxRank, Ext, Ord>& r) {
+                          btas::zb::RangeNd<_Order, Ext, Ord, MaxRank>& r) {
     std::uint8_t rank{};
     ar& rank;
-    typename btas::zb::RangeNd<MaxRank, Ext, Ord>::extent_type ext(
+    // Guard against malformed archives: rank must fit in MaxRank,
+    // otherwise the underlying btas::zb::index would truncate the size_
+    // field and corrupt subsequent reads.
+    BTAS_ASSERT(static_cast<std::size_t>(rank) <= MaxRank &&
+                "btas::zb::RangeNd archive load: rank exceeds MaxRank");
+    typename btas::zb::RangeNd<_Order, Ext, Ord, MaxRank>::extent_type ext(
         static_cast<std::size_t>(rank));
     for (std::uint8_t i = 0; i < rank; ++i) ar& ext[i];
-    r = btas::zb::RangeNd<MaxRank, Ext, Ord>(ext);
+    r = btas::zb::RangeNd<_Order, Ext, Ord, MaxRank>(ext);
   }
 };
 
-template <class Archive, std::size_t MaxRank, typename Ext, typename Ord>
-struct ArchiveStoreImpl<Archive, btas::zb::RangeNd<MaxRank, Ext, Ord>> {
-  static inline void store(const Archive& ar,
-                           const btas::zb::RangeNd<MaxRank, Ext, Ord>& r) {
+template <class Archive, ::blas::Layout _Order, typename Ext, typename Ord,
+          std::size_t MaxRank>
+struct ArchiveStoreImpl<Archive, btas::zb::RangeNd<_Order, Ext, Ord, MaxRank>> {
+  static inline void store(
+      const Archive& ar,
+      const btas::zb::RangeNd<_Order, Ext, Ord, MaxRank>& r) {
     const std::uint8_t rank = static_cast<std::uint8_t>(r.rank());
     ar& rank;
     for (std::uint8_t i = 0; i < rank; ++i) ar& r.extent(i);

--- a/btas/zb/range.h
+++ b/btas/zb/range.h
@@ -1,0 +1,402 @@
+/*
+ * zb/range.h
+ *
+ *  Slimmed-down version of RangeNd for zero-based indexing apps. State is just (extent[], rank); lobound is
+ *  structurally zero, upbound = extent, strides are derived row-major on demand.
+ *
+ *  sizeof(zb::RangeNd<6, int16_t, int32_t>) == 14 (vs ~304 for btas::Range).
+ */
+
+#ifndef BTAS_ZB_RANGE_H_
+#define BTAS_ZB_RANGE_H_
+
+#include <btas/fwd.h>
+
+#include <btas/index_traits.h>
+#include <btas/range_iterator.h>
+#include <btas/range_traits.h>
+#include <btas/serialization.h>
+#include <btas/types.h>
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <iterator>
+#include <type_traits>
+
+namespace btas {
+namespace zb {
+
+/// Packed zero-based index/extent vector. Stores at most \c MaxRank entries of
+/// type \c Int plus a 1-byte size; size <= MaxRank invariant is enforced.
+///
+/// Models the TWG.Index concept (\c btas::is_index) — exposes nested
+/// \c value_type plus member \c begin / \c end / \c operator[] / \c size .
+template <std::size_t MaxRank, typename Int>
+class index {
+ public:
+  using value_type = Int;
+  using size_type = std::size_t;
+  using reference = Int&;
+  using const_reference = const Int&;
+  using pointer = Int*;
+  using const_pointer = const Int*;
+  using iterator = Int*;
+  using const_iterator = const Int*;
+
+  static constexpr size_type max_size_v = MaxRank;
+
+  constexpr index() noexcept : data_{}, size_(0) {}
+
+  /// fixed-size construction with default-initialized elements
+  constexpr explicit index(size_type n) : data_{}, size_(check_size(n)) {}
+
+  /// fixed-size construction filled with \p v
+  constexpr index(size_type n, Int v) : data_{}, size_(check_size(n)) {
+    for (size_type i = 0; i < size_; ++i) data_[i] = v;
+  }
+
+  template <typename T>
+  constexpr index(std::initializer_list<T> il) : data_{}, size_(check_size(il.size())) {
+    size_type i = 0;
+    for (auto v : il) data_[i++] = static_cast<Int>(v);
+  }
+
+  /// from any iterable container (size must be <= MaxRank)
+  template <typename C,
+            typename = std::enable_if_t<is_container<std::decay_t<C>>::value &&
+                                        !std::is_same_v<std::decay_t<C>, index>>>
+  constexpr index(const C& c) : data_{}, size_(0) {
+    using std::begin;
+    using std::end;
+    auto first = begin(c);
+    auto last = end(c);
+    size_type n = 0;
+    for (auto it = first; it != last; ++it) ++n;
+    size_ = check_size(n);
+    size_type i = 0;
+    for (auto it = first; it != last; ++it) data_[i++] = static_cast<Int>(*it);
+  }
+
+  constexpr size_type size() const noexcept { return size_; }
+  constexpr bool empty() const noexcept { return size_ == 0; }
+  static constexpr size_type max_size() noexcept { return MaxRank; }
+
+  constexpr reference operator[](size_type i) noexcept { return data_[i]; }
+  constexpr const_reference operator[](size_type i) const noexcept { return data_[i]; }
+
+  constexpr reference at(size_type i) { assert(i < size_); return data_[i]; }
+  constexpr const_reference at(size_type i) const { assert(i < size_); return data_[i]; }
+
+  constexpr iterator begin() noexcept { return data_.data(); }
+  constexpr iterator end() noexcept { return data_.data() + size_; }
+  constexpr const_iterator begin() const noexcept { return data_.data(); }
+  constexpr const_iterator end() const noexcept { return data_.data() + size_; }
+  constexpr const_iterator cbegin() const noexcept { return data_.data(); }
+  constexpr const_iterator cend() const noexcept { return data_.data() + size_; }
+
+  constexpr pointer data() noexcept { return data_.data(); }
+  constexpr const_pointer data() const noexcept { return data_.data(); }
+
+  /// resize to \p n (elements past the old size are value-initialized)
+  constexpr void resize(size_type n) {
+    auto new_size = check_size(n);
+    for (size_type i = size_; i < new_size; ++i) data_[i] = Int{};
+    size_ = new_size;
+  }
+
+  friend constexpr bool operator==(const index& a, const index& b) noexcept {
+    if (a.size_ != b.size_) return false;
+    for (std::uint8_t i = 0; i < a.size_; ++i)
+      if (a.data_[i] != b.data_[i]) return false;
+    return true;
+  }
+  friend constexpr bool operator!=(const index& a, const index& b) noexcept {
+    return !(a == b);
+  }
+
+ private:
+  static constexpr std::uint8_t check_size(size_type n) {
+    assert(n <= MaxRank);
+    return static_cast<std::uint8_t>(n);
+  }
+
+  std::array<Int, MaxRank> data_;
+  std::uint8_t size_;
+};
+
+/// Lightweight value type returned by \c RangeNd::ordinal() . Synthesizes
+/// strides from extent at construction; offset is always 0 and the range is
+/// always contiguous, by construction.
+template <std::size_t MaxRank, typename Ord>
+class ordinal_view {
+ public:
+  using value_type = Ord;
+  using stride_type = std::array<Ord, MaxRank>;
+
+  ordinal_view() noexcept : stride_{}, rank_(0) {}
+
+  template <typename Extents>
+  ordinal_view(const Extents& ext, std::size_t rank) : stride_{}, rank_(rank) {
+    using std::cbegin;
+    auto it = cbegin(ext);
+    Ord vol{1};
+    for (std::ptrdiff_t i = static_cast<std::ptrdiff_t>(rank) - 1; i >= 0; --i) {
+      stride_[i] = vol;
+      vol *= static_cast<Ord>(*(it + i));
+    }
+  }
+
+  std::size_t rank() const noexcept { return rank_; }
+  const stride_type& stride() const noexcept { return stride_; }
+  const Ord* stride_data() const noexcept { return stride_.data(); }
+  constexpr Ord offset() const noexcept { return Ord{0}; }
+  constexpr bool contiguous() const noexcept { return true; }
+
+  template <typename Index>
+  std::enable_if_t<is_index<Index>::value, Ord>
+  operator()(const Index& idx) const {
+    assert(static_cast<std::size_t>(idx.size()) == rank_);
+    using std::cbegin;
+    Ord o{0};
+    auto it = cbegin(idx);
+    for (std::size_t i = 0; i < rank_; ++i)
+      o += static_cast<Ord>(*(it + i)) * stride_[i];
+    return o;
+  }
+
+ private:
+  stride_type stride_;
+  std::size_t rank_;
+};
+
+/// Zero-based row-major N-dim range optimized for applications with zero-based indexing.
+///
+/// \tparam MaxRank static cap on rank (default 6)
+/// \tparam Ext     per-dim extent integer type (default int16_t)
+/// \tparam Ord     ordinal integer type (default int32_t)
+template <std::size_t MaxRank = 6,
+          typename Ext = std::int16_t,
+          typename Ord = std::int32_t>
+class RangeNd {
+ public:
+  static_assert(MaxRank > 0 && MaxRank < 256, "MaxRank must lie in (0, 256)");
+  static_assert(std::is_integral_v<Ext>, "Ext must be an integer type");
+  static_assert(std::is_integral_v<Ord> && std::is_signed_v<Ord>,
+                "Ord must be a signed integer type");
+
+  static constexpr ::blas::Layout order = ::blas::Layout::RowMajor;
+  static constexpr std::size_t max_rank = MaxRank;
+
+  using extent_type = index<MaxRank, Ext>;
+  using index_type = extent_type;
+  using index1_type = Ext;
+  using index_element_type = Ext;
+  using extent_element_type = Ext;
+  using ordinal_type = Ord;
+  using size_type = std::size_t;
+
+  using value_type = index_type;
+  using reference = index_type&;
+  using const_reference = const index_type&;
+
+  using iterator = btas::RangeIterator<index_type, RangeNd>;
+  using const_iterator = iterator;
+  friend class btas::RangeIterator<index_type, RangeNd>;
+
+  /// Default constructor: rank-0 range.
+  constexpr RangeNd() noexcept = default;
+
+  /// Construct from an extent container (rank inferred from size).
+  template <typename C,
+            typename = std::enable_if_t<is_index<std::decay_t<C>>::value &&
+                                        !std::is_same_v<std::decay_t<C>, RangeNd>>>
+  RangeNd(const C& ext) : extent_(ext) {}
+
+  /// Construct from an initializer list of extents.
+  template <typename T,
+            typename = std::enable_if_t<std::is_integral_v<T>>>
+  RangeNd(std::initializer_list<T> il) : extent_(il) {}
+
+  /// Construct from a pack of integer extents (>=2 to avoid clashing with
+  /// the container-taking constructor; pass a one-element \c {e0} for rank-1).
+  template <typename I0, typename I1, typename... Is,
+            typename = std::enable_if_t<
+                std::is_integral_v<I0> && std::is_integral_v<I1> &&
+                (std::is_integral_v<Is> && ...)>>
+  RangeNd(I0 e0, I1 e1, Is... es)
+      : extent_({static_cast<Ext>(e0), static_cast<Ext>(e1),
+                 static_cast<Ext>(es)...}) {}
+
+  //
+  // Rank, extent, lo/up bounds
+  //
+
+  std::size_t rank() const noexcept { return extent_.size(); }
+
+  /// Volume; matches \c btas::BaseRangeNd::area() which returns 0 for rank 0.
+  size_type area() const noexcept {
+    if (extent_.size() == 0) return 0;
+    size_type v = 1;
+    for (std::size_t i = 0; i < extent_.size(); ++i)
+      v *= static_cast<size_type>(extent_[i]);
+    return v;
+  }
+  size_type volume() const noexcept { return area(); }
+
+  const extent_type& extent() const noexcept { return extent_; }
+  Ext extent(std::size_t i) const noexcept { return extent_[i]; }
+  const Ext* extent_data() const noexcept { return extent_.data(); }
+
+  /// Lower bound: always zeros. Returns by value (small, fixed-size object).
+  index_type lobound() const { return index_type(rank(), Ext{0}); }
+  Ext lobound(std::size_t) const noexcept { return Ext{0}; }
+  const Ext* lobound_data() const noexcept { return zero_buffer(); }
+
+  /// Upper bound: equal to extent (zero-based range).
+  const extent_type& upbound() const noexcept { return extent_; }
+  Ext upbound(std::size_t i) const noexcept { return extent_[i]; }
+  const Ext* upbound_data() const noexcept { return extent_.data(); }
+
+  //
+  // Ordinal mapping (synthesized row-major; nothing stored)
+  //
+
+  ordinal_view<MaxRank, Ord> ordinal() const {
+    return ordinal_view<MaxRank, Ord>(extent_, rank());
+  }
+
+  template <typename I>
+  std::enable_if_t<is_index<I>::value, Ord> ordinal(const I& idx) const {
+    assert(static_cast<std::size_t>(idx.size()) == rank());
+    using std::cbegin;
+    auto it = cbegin(idx);
+    const auto r = rank();
+    Ord o{0};
+    Ord vol{1};
+    for (std::ptrdiff_t i = static_cast<std::ptrdiff_t>(r) - 1; i >= 0; --i) {
+      o += static_cast<Ord>(*(it + i)) * vol;
+      vol *= static_cast<Ord>(extent_[i]);
+    }
+    return o;
+  }
+
+  //
+  // Iteration
+  //
+
+  const_iterator begin() const { return const_iterator(lobound(), this); }
+  const_iterator end() const { return const_iterator(extent_, this); }
+  const_iterator cbegin() const { return begin(); }
+  const_iterator cend() const { return end(); }
+
+  /// Row-major in-place increment used by \c RangeIterator . After the final
+  /// valid index, idx == upbound() (== extent_), which matches \c end() .
+  void increment(index_type& idx) const {
+    const auto r = rank();
+    if (r == 0) return;
+    for (std::ptrdiff_t d = static_cast<std::ptrdiff_t>(r) - 1; d >= 0; --d) {
+      ++idx[d];
+      if (idx[d] < extent_[d]) return;
+      idx[d] = Ext{0};
+    }
+    for (std::size_t d = 0; d < r; ++d) idx[d] = extent_[d];
+  }
+
+  //
+  // Equality, swap
+  //
+
+  friend bool operator==(const RangeNd& a, const RangeNd& b) noexcept {
+    return a.extent_ == b.extent_;
+  }
+  friend bool operator!=(const RangeNd& a, const RangeNd& b) noexcept {
+    return !(a == b);
+  }
+
+  void swap(RangeNd& other) noexcept {
+    using std::swap;
+    swap(extent_, other.extent_);
+  }
+
+ private:
+  /// Static MaxRank-sized zero buffer; \c lobound_data() returns a pointer
+  /// into it. Callers iterate only the first \c rank() bytes.
+  static const Ext* zero_buffer() noexcept {
+    static const std::array<Ext, MaxRank> z{};
+    return z.data();
+  }
+
+  extent_type extent_{};
+};
+
+template <std::size_t MaxRank, typename Ext, typename Ord>
+inline void swap(RangeNd<MaxRank, Ext, Ord>& a,
+                 RangeNd<MaxRank, Ext, Ord>& b) noexcept {
+  a.swap(b);
+}
+
+}  // namespace zb
+
+//
+// Trait specializations placing zb::RangeNd into the BTAS Range concept.
+//
+
+template <std::size_t MaxRank, typename Ext, typename Ord>
+struct range_traits<zb::RangeNd<MaxRank, Ext, Ord>> {
+  static constexpr ::blas::Layout order = ::blas::Layout::RowMajor;
+  using index_type = typename zb::RangeNd<MaxRank, Ext, Ord>::index_type;
+  using ordinal_type = Ord;
+  static constexpr bool is_general_layout = false;
+};
+
+template <std::size_t MaxRank, typename Ext, typename Ord>
+class boxrange_iteration_order<zb::RangeNd<MaxRank, Ext, Ord>> {
+ public:
+  enum {
+    row_major = boxrange_iteration_order<void>::row_major,
+    other = boxrange_iteration_order<void>::other,
+    column_major = boxrange_iteration_order<void>::column_major
+  };
+  static constexpr int value = row_major;
+};
+
+}  // namespace btas
+
+//
+// MADNESS archive load/store specializations. Includes only the rank + extents;
+// the ordinal is fully derivable from extent. Caller must have included
+// <madness/world/archive.h> before instantiating these.
+//
+namespace madness {
+namespace archive {
+
+template <class Archive, std::size_t MaxRank, typename Ext, typename Ord>
+struct ArchiveLoadImpl<Archive, btas::zb::RangeNd<MaxRank, Ext, Ord>> {
+  static inline void load(const Archive& ar,
+                          btas::zb::RangeNd<MaxRank, Ext, Ord>& r) {
+    std::uint8_t rank{};
+    ar& rank;
+    typename btas::zb::RangeNd<MaxRank, Ext, Ord>::extent_type ext(
+        static_cast<std::size_t>(rank));
+    for (std::uint8_t i = 0; i < rank; ++i) ar& ext[i];
+    r = btas::zb::RangeNd<MaxRank, Ext, Ord>(ext);
+  }
+};
+
+template <class Archive, std::size_t MaxRank, typename Ext, typename Ord>
+struct ArchiveStoreImpl<Archive, btas::zb::RangeNd<MaxRank, Ext, Ord>> {
+  static inline void store(const Archive& ar,
+                           const btas::zb::RangeNd<MaxRank, Ext, Ord>& r) {
+    const std::uint8_t rank = static_cast<std::uint8_t>(r.rank());
+    ar& rank;
+    for (std::uint8_t i = 0; i < rank; ++i) ar& r.extent(i);
+  }
+};
+
+}  // namespace archive
+}  // namespace madness
+
+#endif  // BTAS_ZB_RANGE_H_

--- a/btas/zb/range.h
+++ b/btas/zb/range.h
@@ -262,12 +262,14 @@ class RangeNd {
             typename = std::enable_if_t<is_index<std::decay_t<Lo>>::value &&
                                         is_index<std::decay_t<Up>>::value>>
   RangeNd(const Lo& lobound, const Up& upbound) : extent_(upbound) {
-    (void)lobound;
     using std::cbegin;
     using std::cend;
+    using std::size;
+    BTAS_ASSERT(size(lobound) == size(upbound) &&
+                "btas::zb::RangeNd: lobound and upbound must have equal rank");
     BTAS_ASSERT(std::all_of(cbegin(lobound), cend(lobound),
-                       [](auto v) { return v == 0; }) &&
-           "btas::zb::RangeNd: lobound must be all zeros");
+                            [](auto v) { return v == 0; }) &&
+                "btas::zb::RangeNd: lobound must be all zeros");
   }
 
   //
@@ -391,7 +393,7 @@ class RangeNd {
 
  private:
   /// Static MaxRank-sized zero buffer; \c lobound_data() returns a pointer
-  /// into it. Callers iterate only the first \c rank() bytes.
+  /// into it. Callers iterate only the first \c rank() elements.
   static const Ext* zero_buffer() noexcept {
     static const std::array<Ext, MaxRank> z{};
     return z.data();

--- a/btas/zb/range.h
+++ b/btas/zb/range.h
@@ -285,6 +285,16 @@ class RangeNd {
     return ordinal_view<MaxRank, Ord>(extent_, rank());
   }
 
+  /// Row-major strides synthesized on demand. Returned by value (not by
+  /// reference) so nothing is stored in the range itself — preserves the
+  /// packed footprint. Callers that need a pointer (e.g. the BTAS generic
+  /// permute, which forwards r.stride() into a btas::Range ctor) bind the
+  /// temporary to a const& and copy from it.
+  using stride_type = typename ordinal_view<MaxRank, Ord>::stride_type;
+  stride_type stride() const noexcept {
+    return ordinal().stride();
+  }
+
   template <typename I>
   std::enable_if_t<is_index<I>::value, Ord> ordinal(const I& idx) const {
     BTAS_ASSERT(static_cast<std::size_t>(idx.size()) == rank());

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -10,6 +10,7 @@ set(btas_test_src_files
         tensor_lapack_test.cc
         tensor_test.cc
         tensorview_test.cc
+        zb_range_test.cc
         ztensor_cp_test.cc
         test.cc
         )

--- a/unittest/tensor_test.cc
+++ b/unittest/tensor_test.cc
@@ -134,6 +134,25 @@ TEST_CASE("Tensor Constructors") {
 
     // range + vector of values
     CHECK_NOTHROW(DTensor(r1, T1.data()));
+
+    // range + generator lambda: gen(multi-index) → value
+    Range r2(3, 4);
+    DTensor T2(r2, [](auto const& idx) -> double {
+      return 10.0 * idx[0] + idx[1];
+    });
+    CHECK(T2.rank() == 2);
+    CHECK(T2.extent(0) == 3);
+    CHECK(T2.extent(1) == 4);
+    CHECK(T2.size() == 3 * 4);
+    for (auto i = 0u; i != 3; ++i)
+      for (auto j = 0u; j != 4; ++j)
+        CHECK(T2(i, j) == Approx(10.0 * i + j));
+
+    // generator returning an int (convertible to double) should also work
+    Tensor<int> Ti2(r2, [](auto const& idx) { return idx[0] + idx[1]; });
+    CHECK(Ti2.extent(0) == 3);
+    CHECK(Ti2.extent(1) == 4);
+    CHECK(Ti2(2, 3) == 5);
   }
 
   SECTION("Fixed Rank Tensor") {

--- a/unittest/zb_range_test.cc
+++ b/unittest/zb_range_test.cc
@@ -150,7 +150,7 @@ TEST_CASE("zb::RangeNd equality and swap") {
 }
 
 TEST_CASE("zb::RangeNd with non-default template parameters") {
-  using R4 = RangeNd<4, std::int32_t, std::int64_t>;
+  using R4 = RangeNd<::blas::Layout::RowMajor, std::int32_t, std::int64_t, 4>;
   static_assert(sizeof(R4) == 20, "expected packed size for MaxRank=4, int32");
   static_assert(R4::max_rank == 4);
   R4 r(10, 20, 30);
@@ -158,4 +158,27 @@ TEST_CASE("zb::RangeNd with non-default template parameters") {
   CHECK(r.area() == 6000);
   CHECK(r.ordinal(typename R4::index_type{1, 2, 3}) ==
         1 * 20 * 30 + 2 * 30 + 3);
+}
+
+TEST_CASE("zb::RangeNd column-major layout") {
+  using RC = RangeNd<::blas::Layout::ColMajor>;
+  RC r(10, 20, 30);
+  CHECK(r.rank() == 3);
+  CHECK(r.area() == 6000);
+  // col-major: ordinal = i0 + i1*ext0 + i2*ext0*ext1
+  CHECK(r.ordinal(typename RC::index_type{1, 2, 3}) ==
+        1 + 2 * 10 + 3 * 10 * 20);
+  // strides[0]=1, strides[1]=ext0=10, strides[2]=ext0*ext1=200
+  auto s = r.stride();
+  CHECK(s[0] == 1);
+  CHECK(s[1] == 10);
+  CHECK(s[2] == 200);
+  // Iteration covers volume in column-major order.
+  std::size_t count = 0;
+  typename RC::index_type prev;
+  for (auto&& idx : r) {
+    (void)idx;
+    ++count;
+  }
+  CHECK(count == r.area());
 }

--- a/unittest/zb_range_test.cc
+++ b/unittest/zb_range_test.cc
@@ -1,0 +1,161 @@
+#include "test.h"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "btas/zb/range.h"
+
+using btas::zb::RangeNd;
+// NB: do NOT `using btas::zb::index` at file scope — macOS POSIX <strings.h>
+// declares ::index(const char*, int) and the names collide.
+
+// Sizeof contract: this is the whole point of zb::RangeNd. Default
+// MaxRank=6 / Ext=int16_t / Ord=int32_t must fit in 14 bytes (12 B extents +
+// 1 B size, alignment 2).
+static_assert(sizeof(RangeNd<>) == 14, "zb::RangeNd<> must be 14 bytes");
+static_assert(alignof(RangeNd<>) == 2, "zb::RangeNd<> must align to 2");
+
+// Index concept membership: TWG.Index is what btas::Tensor and the
+// expression layer check via SFINAE.
+static_assert(btas::is_index<typename RangeNd<>::index_type>::value,
+              "zb::index must model btas::is_index");
+static_assert(btas::is_boxrange<RangeNd<>>::value,
+              "zb::RangeNd must model btas::is_boxrange");
+static_assert(btas::boxrange_iteration_order<RangeNd<>>::value ==
+                  btas::boxrange_iteration_order<void>::row_major,
+              "zb::RangeNd must be row-major");
+
+TEST_CASE("zb::index basics") {
+  using Idx = btas::zb::index<6, std::int16_t>;
+
+  SECTION("default") {
+    Idx a;
+    CHECK(a.size() == 0);
+    CHECK(a.empty());
+    CHECK(a == Idx{});
+  }
+
+  SECTION("initializer list") {
+    Idx a{2, 3, 4};
+    CHECK(a.size() == 3);
+    CHECK(a[0] == 2);
+    CHECK(a[1] == 3);
+    CHECK(a[2] == 4);
+  }
+
+  SECTION("from container") {
+    std::vector<int> v{5, 6};
+    Idx a(v);
+    CHECK(a.size() == 2);
+    CHECK(a[0] == 5);
+    CHECK(a[1] == 6);
+  }
+
+  SECTION("equality") {
+    CHECK(Idx{1, 2} == Idx{1, 2});
+    CHECK(Idx{1, 2} != Idx{1, 2, 3});
+    CHECK(Idx{1, 2} != Idx{2, 1});
+  }
+}
+
+TEST_CASE("zb::RangeNd construction and accessors") {
+  SECTION("default is rank-0, area()==0") {
+    RangeNd<> r;
+    CHECK(r.rank() == 0);
+    CHECK(r.area() == 0);  // matches btas::BaseRangeNd::area() convention
+  }
+
+  SECTION("from variadic extents") {
+    RangeNd<> r(2, 3, 4);
+    CHECK(r.rank() == 3);
+    CHECK(r.area() == 24);
+    CHECK(r.extent(0) == 2);
+    CHECK(r.extent(1) == 3);
+    CHECK(r.extent(2) == 4);
+  }
+
+  SECTION("from initializer list") {
+    RangeNd<> r{5, 7};
+    CHECK(r.rank() == 2);
+    CHECK(r.area() == 35);
+  }
+
+  SECTION("lobound is zeros, upbound is extent") {
+    RangeNd<> r(2, 3, 4);
+    auto lo = r.lobound();
+    CHECK(lo.size() == 3);
+    CHECK(lo[0] == 0);
+    CHECK(lo[1] == 0);
+    CHECK(lo[2] == 0);
+    CHECK(r.upbound() == r.extent());
+    CHECK(r.upbound_data() == r.extent_data());
+  }
+
+  SECTION("lobound_data points to MaxRank zeros") {
+    RangeNd<> r(2, 3);
+    auto* p = r.lobound_data();
+    for (std::size_t i = 0; i < RangeNd<>::max_rank; ++i) CHECK(p[i] == 0);
+  }
+}
+
+TEST_CASE("zb::RangeNd ordinal mapping is row-major contiguous") {
+  RangeNd<> r(2, 3, 4);
+
+  SECTION("formula") {
+    // row-major: ord(i,j,k) = i*(3*4) + j*4 + k
+    using idx_t = RangeNd<>::index_type;
+    CHECK(r.ordinal(idx_t{0, 0, 0}) == 0);
+    CHECK(r.ordinal(idx_t{0, 0, 1}) == 1);
+    CHECK(r.ordinal(idx_t{0, 1, 0}) == 4);
+    CHECK(r.ordinal(idx_t{1, 0, 0}) == 12);
+    CHECK(r.ordinal(idx_t{1, 2, 3}) == 23);
+  }
+
+  SECTION("ordinal_view exposes strides and is contiguous") {
+    auto ov = r.ordinal();
+    CHECK(ov.rank() == 3);
+    CHECK(ov.contiguous());
+    CHECK(ov.offset() == 0);
+    CHECK(ov.stride()[0] == 12);
+    CHECK(ov.stride()[1] == 4);
+    CHECK(ov.stride()[2] == 1);
+    using idx_t = RangeNd<>::index_type;
+    CHECK(ov(idx_t{1, 2, 3}) == 23);
+  }
+}
+
+TEST_CASE("zb::RangeNd iteration covers volume in row-major order") {
+  RangeNd<> r(2, 3);
+  std::size_t count = 0;
+  std::int32_t expected_ordinal = 0;
+  for (auto it = r.begin(); it != r.end(); ++it, ++count, ++expected_ordinal) {
+    CHECK(r.ordinal(*it) == expected_ordinal);
+  }
+  CHECK(count == r.area());
+}
+
+TEST_CASE("zb::RangeNd equality and swap") {
+  RangeNd<> a(2, 3, 4);
+  RangeNd<> b(2, 3, 4);
+  RangeNd<> c(2, 3, 5);
+
+  CHECK(a == b);
+  CHECK(a != c);
+
+  using std::swap;
+  swap(a, c);
+  CHECK(a == RangeNd<>(2, 3, 5));
+  CHECK(c == RangeNd<>(2, 3, 4));
+}
+
+TEST_CASE("zb::RangeNd with non-default template parameters") {
+  using R4 = RangeNd<4, std::int32_t, std::int64_t>;
+  static_assert(sizeof(R4) == 20, "expected packed size for MaxRank=4, int32");
+  static_assert(R4::max_rank == 4);
+  R4 r(10, 20, 30);
+  CHECK(r.rank() == 3);
+  CHECK(r.area() == 6000);
+  CHECK(r.ordinal(typename R4::index_type{1, 2, 3}) ==
+        1 * 20 * 30 + 2 * 30 + 3);
+}

--- a/unittest/zb_range_test.cc
+++ b/unittest/zb_range_test.cc
@@ -173,11 +173,11 @@ TEST_CASE("zb::RangeNd column-major layout") {
   CHECK(s[0] == 1);
   CHECK(s[1] == 10);
   CHECK(s[2] == 200);
-  // Iteration covers volume in column-major order.
+  // Iteration covers volume — and the ordinal of each visited index must
+  // equal the iteration count, which validates column-major traversal order.
   std::size_t count = 0;
-  typename RC::index_type prev;
   for (auto&& idx : r) {
-    (void)idx;
+    CHECK(r.ordinal(idx) == static_cast<RC::ordinal_type>(count));
     ++count;
   }
   CHECK(count == r.area());


### PR DESCRIPTION
## Summary

- Adds `btas::zb::RangeNd<MaxRank=6, Ext=int16_t, Ord=int32_t>` — a zero-based, packed `RangeNd` for Tensor-of-Tensor inner tiles where `lobound ≡ 0`, `upbound ≡ extent`, strides are derivable, offset is 0, and the rank is small (≤ 6).
- State is just `std::array<Ext, MaxRank> extent_` + `uint8_t rank_`. `sizeof = 14 B`, `align = 2`, vs. `~304 B` for the general-purpose `btas::Range`.
- Strides are synthesized on demand via an `ordinal_view` value returned from `RangeNd::ordinal()`; `lobound()` materializes zeros from a static buffer.
- Models `TWG.BoxRange` (`range_traits`, `is_index`, `boxrange_iteration_order` specializations) and provides MADNESS `ArchiveLoadImpl` / `ArchiveStoreImpl` that serialize rank + extents only (ordinal is derivable).
- Motivated by TiledArray ToT (`TA::Tensor<btas::Tensor<T, btas::zb::RangeNd<>, …>>`) where per-inner-tile range overhead dominates.

## Test plan

- [x] New `unittest/zb_range_test.cc` — 6 test cases / 60 assertions covering sizeof/alignof contracts, concept membership, construction (default → rank-0 + `area()==0`, variadic, initializer-list, from container), lobound/upbound/extent accessors, row-major ordinal formula and `ordinal_view` strides, index iteration order, equality, swap, and non-default template parameters.
- [x] `btas_test` builds clean on macOS (arm64, clang + C++20).
- [x] All zb test cases pass locally: `All tests passed (60 assertions in 6 test cases)`.